### PR TITLE
Feat/support v0.7

### DIFF
--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -447,6 +447,7 @@ class Analyzer {
       case "BoolLit":
       case "NullLit":
       case "UndefinedLit":
+      case "NanLit":
       case "This":
       case "Super":
         break;

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -255,6 +255,12 @@ export interface ContinueStmt {
   span: Span;
 }
 
+export interface ImportAttribute {
+  key: string;
+  value: string;
+  span: Span;
+}
+
 export interface ImportStmt {
   type: "Import";
   defaultName?: string;
@@ -263,12 +269,14 @@ export interface ImportStmt {
   namespaceName?: string;
   namespaceNameSpan?: Span;
   source: string;
+  attributes?: ImportAttribute[];
   span: Span;
 }
 
 export interface SideEffectImportStmt {
   type: "SideEffectImport";
   source: string;
+  attributes?: ImportAttribute[];
   span: Span;
 }
 
@@ -348,6 +356,7 @@ export type Expr =
   | BoolLitExpr
   | NullLitExpr
   | UndefinedLitExpr
+  | NanLitExpr
   | IdentExpr
   | ThisExpr
   | SuperExpr
@@ -415,6 +424,11 @@ export interface NullLitExpr {
 
 export interface UndefinedLitExpr {
   type: "UndefinedLit";
+  span: Span;
+}
+
+export interface NanLitExpr {
+  type: "NanLit";
   span: Span;
 }
 

--- a/src/keywords.ts
+++ b/src/keywords.ts
@@ -46,6 +46,7 @@ const keywords: KeywordInfo[] = [
   { label: "or", detail: "|| (logical OR)", documentation: "論理和。`a or b` → `a || b`", kind: CompletionItemKind.Operator },
   { label: "not", detail: "! (logical NOT)", documentation: "論理否定。`not x` → `!x`", kind: CompletionItemKind.Operator },
   { label: "pipe", detail: "| (pipe operator)", documentation: "パイプ演算子。左の値を右の関数に渡す。`x pipe f` → `f(x)`", kind: CompletionItemKind.Operator },
+  { label: "coal", detail: "?? (nullish coalescing)", documentation: "Null 合体演算子。`a coal b` → `a ?? b`", kind: CompletionItemKind.Operator },
 
   // Conditionals
   { label: "if", detail: "if", documentation: "条件分岐。後置形式も可: `stmt if cond`", kind: CompletionItemKind.Keyword },
@@ -83,6 +84,7 @@ const keywords: KeywordInfo[] = [
   { label: "namespace", detail: "namespace (IIFE)", documentation: "名前空間を宣言。IIFE にコンパイルされる。`namespace mymod` → `const mymod = (() => { ... })()`", kind: CompletionItemKind.Keyword },
   { label: "pub", detail: "export (public)", documentation: "宣言を公開/エクスポートする。`pub fn name` → `export function name`", kind: CompletionItemKind.Keyword },
   { label: "all", detail: "* as (namespace import)", documentation: "名前空間インポート。`import all as ns from ///path///`", kind: CompletionItemKind.Keyword },
+  { label: "with", detail: "import attributes", documentation: "インポート属性。`import data from ///data.json/// with [ type be ///json/// ]`", kind: CompletionItemKind.Keyword },
 
   // Type System
   { label: "is", detail: "typeof/instanceof", documentation: "型チェック。`x is string` → `typeof x === \"string\"`. `x is MyClass` → `x instanceof MyClass`", kind: CompletionItemKind.Operator },
@@ -98,12 +100,22 @@ const keywords: KeywordInfo[] = [
   { label: "null", detail: "null", documentation: "null リテラル", kind: CompletionItemKind.Value },
   { label: "nil", detail: "null (alias)", documentation: "null のエイリアス（`null` の使用を推奨）", kind: CompletionItemKind.Value },
   { label: "undefined", detail: "undefined", documentation: "undefined リテラル", kind: CompletionItemKind.Value },
+  { label: "nan", detail: "NaN", documentation: "NaN リテラル。`nan` → `NaN`", kind: CompletionItemKind.Value },
 
   // OOP / Reference
   { label: "new", detail: "new", documentation: "インスタンスを生成。`new Foo[args]` → `new Foo(args)`", kind: CompletionItemKind.Keyword },
   { label: "delete", detail: "delete", documentation: "プロパティを削除。`delete obj.key` → `delete obj.key`", kind: CompletionItemKind.Keyword },
   { label: "this", detail: "this", documentation: "現在のオブジェクトへの参照", kind: CompletionItemKind.Keyword },
   { label: "await", detail: "await", documentation: "async fn 内で Promise を待機する", kind: CompletionItemKind.Keyword },
+
+  // Class
+  { label: "class", detail: "class", documentation: "クラスを宣言する。`class Name` → `class Name { ... }`", kind: CompletionItemKind.Keyword },
+  { label: "extends", detail: "extends", documentation: "クラスの継承。`class Dog extends Animal` → `class Dog extends Animal`", kind: CompletionItemKind.Keyword },
+  { label: "super", detail: "super", documentation: "親クラスのコンストラクタ/メソッドを呼び出す。`super[args]` → `super(args)`", kind: CompletionItemKind.Keyword },
+  { label: "static", detail: "static", documentation: "静的メソッドを宣言。`static fn name` → `static name() { ... }`", kind: CompletionItemKind.Keyword },
+  { label: "private", detail: "# (private field)", documentation: "プライベートフィールドを宣言。`private name` → `#name`", kind: CompletionItemKind.Keyword },
+  { label: "get", detail: "get (accessor)", documentation: "ゲッターアクセサ。`get fn name to expr` → `get name() { return expr; }`", kind: CompletionItemKind.Keyword },
+  { label: "set", detail: "set (accessor)", documentation: "セッターアクセサ。`set fn name value` → `set name(value) { ... }`", kind: CompletionItemKind.Keyword },
 
   // Collection Literals
   { label: "list", detail: "[...] (array)", documentation: "配列リテラル。`list [a, b, c]` → `[a, b, c]`", kind: CompletionItemKind.Keyword },

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,7 +1,7 @@
 import { Token, TokenKind, Span, Position } from "./token";
 import {
   Program, Stmt, Expr, Param, FnBody, MatchArm, MatchArmBody,
-  ClassMember, ObjectEntry, BinaryOp, PostfixModifier,
+  ClassMember, ObjectEntry, BinaryOp, PostfixModifier, ImportAttribute,
 } from "./ast";
 
 export interface ParseError {
@@ -628,7 +628,8 @@ class Parser {
     // Side-effect import: import ///path///
     if (this.check(TokenKind.Str)) {
       const source = this.advance().value as string;
-      return { type: "SideEffectImport", source, span: this.spanFrom(start) };
+      const attributes = this.parseImportAttributes();
+      return { type: "SideEffectImport", source, attributes, span: this.spanFrom(start) };
     }
 
     // import all as name from ///path///
@@ -638,11 +639,13 @@ class Parser {
       const nameToken = this.expect(TokenKind.Ident, "Expected identifier");
       this.expect(TokenKind.From, "Expected 'from'");
       const source = this.expect(TokenKind.Str, "Expected string").value as string;
+      const attributes = this.parseImportAttributes();
       return {
         type: "Import",
         namespaceName: nameToken.text,
         namespaceNameSpan: nameToken.span,
         source,
+        attributes,
         span: this.spanFrom(start),
       };
     }
@@ -654,10 +657,12 @@ class Parser {
       this.expect(TokenKind.RBracket, "Expected ']'");
       this.expect(TokenKind.From, "Expected 'from'");
       const source = this.expect(TokenKind.Str, "Expected string").value as string;
+      const attributes = this.parseImportAttributes();
       return {
         type: "Import",
         names,
         source,
+        attributes,
         span: this.spanFrom(start),
       };
     }
@@ -675,6 +680,7 @@ class Parser {
 
     this.expect(TokenKind.From, "Expected 'from'");
     const source = this.expect(TokenKind.Str, "Expected string").value as string;
+    const attributes = this.parseImportAttributes();
 
     return {
       type: "Import",
@@ -682,8 +688,29 @@ class Parser {
       defaultNameSpan: defaultNameToken.span,
       names,
       source,
+      attributes,
       span: this.spanFrom(start),
     };
+  }
+
+  private parseImportAttributes(): ImportAttribute[] | undefined {
+    if (!this.check(TokenKind.With)) return undefined;
+    this.advance(); // with
+    this.expect(TokenKind.LBracket, "Expected '['");
+    const attrs: ImportAttribute[] = [];
+    while (!this.check(TokenKind.RBracket) && !this.check(TokenKind.Eof)) {
+      const attrStart = this.peek().span.start;
+      const keyToken = this.expect(TokenKind.Ident, "Expected attribute key");
+      this.expect(TokenKind.Be, "Expected 'be'");
+      const valueToken = this.expect(TokenKind.Str, "Expected string value");
+      attrs.push({
+        key: keyToken.text,
+        value: valueToken.value as string,
+        span: this.spanFrom(attrStart),
+      });
+    }
+    this.expect(TokenKind.RBracket, "Expected ']'");
+    return attrs.length > 0 ? attrs : undefined;
   }
 
   private parseUse(): Stmt {
@@ -1375,6 +1402,10 @@ class Parser {
       case TokenKind.Undefined: {
         this.advance();
         return { type: "UndefinedLit", span: token.span };
+      }
+      case TokenKind.Nan: {
+        this.advance();
+        return { type: "NanLit", span: token.span };
       }
       case TokenKind.This: {
         this.advance();

--- a/src/semantic-tokens.ts
+++ b/src/semantic-tokens.ts
@@ -101,6 +101,7 @@ function mapToken(token: Token, rootScope: Scope): [TokenTypeIndex, TokenModifie
     case TokenKind.Namespace:
     case TokenKind.Pub:
     case TokenKind.All:
+    case TokenKind.With:
     case TokenKind.Async:
     case TokenKind.Await:
     case TokenKind.New:
@@ -159,6 +160,7 @@ function mapToken(token: Token, rootScope: Scope): [TokenTypeIndex, TokenModifie
     case TokenKind.Null:
     case TokenKind.Nil:
     case TokenKind.Undefined:
+    case TokenKind.Nan:
       return [typeIndex["enumMember"], 0];
 
     // Comments

--- a/src/token.ts
+++ b/src/token.ts
@@ -117,11 +117,13 @@ export enum TokenKind {
   Namespace,
   Pub,
   All,
+  With,
 
   // Null family
   Null,
   Nil,
   Undefined,
+  Nan,
 
   // Collection
   List,
@@ -231,11 +233,13 @@ export const KEYWORDS: ReadonlyMap<string, TokenKind> = new Map([
   ["namespace", TokenKind.Namespace],
   ["pub", TokenKind.Pub],
   ["all", TokenKind.All],
+  ["with", TokenKind.With],
   ["true", TokenKind.True],
   ["false", TokenKind.False],
   ["null", TokenKind.Null],
   ["nil", TokenKind.Nil],
   ["undefined", TokenKind.Undefined],
+  ["nan", TokenKind.Nan],
   ["list", TokenKind.List],
   ["object", TokenKind.Object],
 ]);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * NaN リテラル式が利用可能になりました
  * インポートステートメントに属性を追加できるようになりました
  * クラス関連キーワード（class、extends、super、static、private、get、set）のサポートを追加
  * ロジック演算子と追加キーワード（with、nullish coalescing）の補完サポートを強化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->