### PR TITLE
fix(lexer): remove protected→private keyword alias

### DIFF
--- a/src/token.ts
+++ b/src/token.ts
@@ -252,7 +252,6 @@ export const KEYWORDS: ReadonlyMap<string, TokenKind> = new Map([
   ["void", TokenKind.Void],
   ["infinity", TokenKind.Infinity],
   ["function", TokenKind.Fn],
-  ["protected", TokenKind.Private],
   ["try", TokenKind.Try],
   ["catch", TokenKind.Catch],
   ["finally", TokenKind.Finally],


### PR DESCRIPTION
## Summary

- `["protected", TokenKind.Private]` を KEYWORDS マップから削除
- `protected` キーワードが `#name` (JS private field) にサイレント変換される問題を修正
- サブクラスアクセスが診断なしに破壊されていた

## Root Cause

`feat/support-v0.9` ブランチで追加された keyword map エントリが `protected` を `TokenKind.Private` にエイリアスしていた。これにより `protected name` がプライベートフィールドとして解析され、サブクラスからのアクセスが不可能になっていた。

## Fix

`protected` を KEYWORDS マップから除外。レキサーは `Ident` トークンとして返すため既存コードへの影響はなく、将来的に `TokenKind.Protected` を追加して正式サポートできる状態。

## Test plan

- [ ] `protected field` を持つクラスが `Ident` として正しくトークナイズされることを確認
- [ ] `private field` が引き続き `TokenKind.Private` → `#field` に変換されることを確認
- [ ] 既存テストがすべてパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)